### PR TITLE
feat(upload-menu): extend popup widget component

### DIFF
--- a/kaltura-ui/src/popup-widget/popup-widget.component.html
+++ b/kaltura-ui/src/popup-widget/popup-widget.component.html
@@ -1,4 +1,9 @@
-<div #container class="kPopupWidget" [style.display]="(state$ | async)?.state !== 'close' ? 'block' : 'none'" [style.width]="popupWidth+'px'" [style.height]="_popupWidgetHeight">
+<div #container
+     class="kPopupWidget"
+     [class.transparent]="transparent"
+     [style.display]="(state$ | async)?.state !== 'close' ? 'block' : 'none'"
+     [style.width]="popupWidth+'px'"
+     [style.height]="_popupWidgetHeight">
     <div class="tooltipUp" *ngIf="showTooltip" [style.marginLeft]="popupWidth/2-12+'px'"></div>
     <i *ngIf="closeBtn" class="kCloseBtn kIconclose_small" [class.closeBtnInside]="closeBtnInside" (click)="close()"></i>
     <div class="kPopupWidgetContent" *ngIf="isShow">

--- a/kaltura-ui/src/popup-widget/popup-widget.component.scss
+++ b/kaltura-ui/src/popup-widget/popup-widget.component.scss
@@ -8,6 +8,10 @@
     border-radius: 4px;
     overflow: hidden;
     box-shadow: 0 16px 20px 0 rgba(0,0,0,0.3);
+    &.transparent {
+        box-shadow: none;
+        background: 0;
+    }
     .kCloseBtn:not(.closeBtnInside) {
         position: absolute;
         right: -118px;

--- a/kaltura-ui/src/popup-widget/popup-widget.component.ts
+++ b/kaltura-ui/src/popup-widget/popup-widget.component.ts
@@ -21,7 +21,7 @@ export type popupStatus = {
     styleUrls: ['./popup-widget.component.scss']
 })
 export class PopupWidgetComponent implements AfterViewInit, OnDestroy, OnInit{
-
+	@Input() transparent = false;
 	@Input() appendTo: any;
 	@Input() popupWidth: number;
     @Input() popupHeight: number | 'auto' = 'auto';


### PR DESCRIPTION
Add transparent popup's background option

### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [] Bugfix
- [x] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
kPopupWidget opens with a visible white rectangle area


**What is the new behavior?**
Added ability to make background of the widget transparent


**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**
