### PR TITLE
add input to k-area-blocker to customize error message title

### DIFF
--- a/kaltura-ui/src/area-blocker/area-blocker-message.ts
+++ b/kaltura-ui/src/area-blocker/area-blocker-message.ts
@@ -6,11 +6,13 @@ export interface AreaBlockerMessageButton
 
 export class AreaBlockerMessage
 {
+    title   : string;
     message : string;
     buttons : AreaBlockerMessageButton[];
 
-    constructor(content : { message : string, buttons : AreaBlockerMessageButton[]})
+    constructor(content : { title? : string, message : string, buttons : AreaBlockerMessageButton[]})
     {
+        this.title = content.title || 'Uh oh!';
         this.message = content.message;
         this.buttons = content.buttons;
     }

--- a/kaltura-ui/src/area-blocker/area-blocker.component.html
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.html
@@ -7,7 +7,7 @@
   </div>
   <div  class="kErrorMessageContainer" *ngIf="_message">
     <div class="kErrorMessage">
-      <div class="kErrorMessageTitle">Uh oh!</div>
+      <div class="kErrorMessageTitle">{{ errorMessageTitle }}</div>
       <div class="kErrorMessageText">{{ _message.message }}</div>
       <div class="kErrorButtons">
         <button *ngFor="let button of _message.buttons" (click)="handleAction(button)">{{button.label}}</button>

--- a/kaltura-ui/src/area-blocker/area-blocker.component.html
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.html
@@ -7,7 +7,7 @@
   </div>
   <div  class="kErrorMessageContainer" *ngIf="_message">
     <div class="kErrorMessage">
-      <div class="kErrorMessageTitle">{{ errorMessageTitle }}</div>
+      <div class="kErrorMessageTitle">{{ _message.title }}</div>
       <div class="kErrorMessageText">{{ _message.message }}</div>
       <div class="kErrorButtons">
         <button *ngFor="let button of _message.buttons" (click)="handleAction(button)">{{button.label}}</button>

--- a/kaltura-ui/src/area-blocker/area-blocker.component.ts
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.ts
@@ -15,6 +15,7 @@ export class AreaBlockerComponent implements OnInit  {
   public _message : AreaBlockerMessage;
 
   @Input() showLoader : boolean;
+  @Input() errorMessageTitle = 'Uh oh!';
 
   @Input()
   set message(value : AreaBlockerMessage | string)

--- a/kaltura-ui/src/area-blocker/area-blocker.component.ts
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.ts
@@ -15,14 +15,13 @@ export class AreaBlockerComponent implements OnInit  {
   public _message : AreaBlockerMessage;
 
   @Input() showLoader : boolean;
-  @Input() errorMessageTitle = 'Uh oh!';
 
   @Input()
   set message(value : AreaBlockerMessage | string)
   {
     if (typeof value === 'string')
     {
-      this._message = { message : value, buttons : [{ label :'Dismiss', action : () => { this._message = null;}}]};
+      this._message = { title : 'Uh oh!', message : value, buttons : [{ label :'Dismiss', action : () => { this._message = null;}}]};
     }else if (value instanceof AreaBlockerMessage)
     {
       this._message = value;


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [] Bugfix
- [x] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The `k-area-blocker` component shows hard-coded "Uh oh!" as the title of the modal. It should allow customization (for localization, etc.).


**What is the new behavior?**
The 'message' input now allows changing the (default = 'Uh oh!') error message title.


**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kaltura-ng/7)
<!-- Reviewable:end -->
