### PR TITLE
KMS-15583 allow adding classes to area blocker message buttons

### DIFF
--- a/kaltura-ui/src/area-blocker/area-blocker-message.ts
+++ b/kaltura-ui/src/area-blocker/area-blocker-message.ts
@@ -1,7 +1,8 @@
 export interface AreaBlockerMessageButton
 {
     label : string;
-    action : () => void
+    action : () => void;
+    classes?: string;
 }
 
 export class AreaBlockerMessage

--- a/kaltura-ui/src/area-blocker/area-blocker.component.html
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.html
@@ -10,11 +10,8 @@
       <div class="kErrorMessageTitle">{{ _message.title }}</div>
       <div class="kErrorMessageText">{{ _message.message }}</div>
       <div class="kErrorButtons">
-        <button *ngFor="let button of _message.buttons" (click)="handleAction(button)">{{button.label}}</button>
+        <button *ngFor="let button of _message.buttons" (click)="handleAction(button)" [ngClass]="button.classes">{{button.label}}</button>
       </div>
     </div>
   </div>
 </div>
-
-
-


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [] Bugfix
- [x] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When using the `k-area-blocker` component to create an error/prompt message, it is impossible to assign classes for each button.


**What is the new behavior?**
A new *optional* property is added to the button interface (`AreaBlockerMessageButton`), which allows you to add classes for each button you add.

**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kaltura-ng/17)
<!-- Reviewable:end -->
