### PR TITLE
KMS-15911 add visible class indicating the area blocker state; this w…

### DIFF
--- a/kaltura-ui/src/area-blocker/area-blocker.component.ts
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, Input, OnInit, Renderer2, ViewEncapsulation } from '@angular/core';
 import { AreaBlockerMessage } from './area-blocker-message';
 
 
@@ -14,6 +14,8 @@ export class AreaBlockerComponent implements OnInit  {
 
   public _message : AreaBlockerMessage;
 
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {}
+
   @Input() showLoader : boolean;
   @Input() centerOnScreen : boolean = false;
   @Input() spinnerMarginTop : number = 0;
@@ -22,17 +24,28 @@ export class AreaBlockerComponent implements OnInit  {
   @Input()
   set message(value : AreaBlockerMessage | string)
   {
-    if (typeof value === 'string')
-    {
-      this._message = { title : 'Error', message : value, buttons : [{ label :'Dismiss', action : () => { this._message = null;}}]};
-    }else if (value instanceof AreaBlockerMessage)
-    {
+    if (typeof value === 'string') {
+      this._message = this.stringToMessage(value);
+      this.renderer.addClass(this.elementRef.nativeElement, "visible");
+    } else if (value instanceof AreaBlockerMessage) {
+      this.renderer.addClass(this.elementRef.nativeElement, "visible");
       this._message = value;
-    }else
-    {
+    } else {
+        this.renderer.removeClass(this.elementRef.nativeElement, "visible");
       this._message = null;
     }
   }
+
+  private stringToMessage = (value : string) => new AreaBlockerMessage({
+      title : 'Error',
+      message : value,
+      buttons : [
+          {
+            label :'Dismiss',
+            action : () => this._message = null
+          }
+      ]
+  });
 
   public handleAction(button : { action : () => void}) {
     if (button) {

--- a/kaltura-ui/src/area-blocker/area-blocker.component.ts
+++ b/kaltura-ui/src/area-blocker/area-blocker.component.ts
@@ -14,9 +14,10 @@ export class AreaBlockerComponent implements OnInit  {
 
   public _message : AreaBlockerMessage;
 
+  private _showLoader: boolean;
+
   constructor(private elementRef: ElementRef, private renderer: Renderer2) {}
 
-  @Input() showLoader : boolean;
   @Input() centerOnScreen : boolean = false;
   @Input() spinnerMarginTop : number = 0;
   @Input() classes : string;
@@ -26,14 +27,26 @@ export class AreaBlockerComponent implements OnInit  {
   {
     if (typeof value === 'string') {
       this._message = this.stringToMessage(value);
-      this.renderer.addClass(this.elementRef.nativeElement, "visible");
+      this.renderer.addClass(this.elementRef.nativeElement, "kVisible");
     } else if (value instanceof AreaBlockerMessage) {
-      this.renderer.addClass(this.elementRef.nativeElement, "visible");
+      this.renderer.addClass(this.elementRef.nativeElement, "kVisible");
       this._message = value;
     } else {
-        this.renderer.removeClass(this.elementRef.nativeElement, "visible");
+        this.renderer.removeClass(this.elementRef.nativeElement, "kVisible");
       this._message = null;
     }
+  }
+  @Input()
+  set showLoader(value: boolean) {
+      this._showLoader = value;
+      if (value) {
+          this.renderer.addClass(this.elementRef.nativeElement, 'kLoading');
+          return;
+      }
+      this.renderer.removeClass(this.elementRef.nativeElement, 'kLoading');
+  }
+  get showLoader() {
+      return this._showLoader;
   }
 
   private stringToMessage = (value : string) => new AreaBlockerMessage({


### PR DESCRIPTION
…ill allow users to have extra CSS logic based on the area blocker state

### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [] Bugfix
- [X] Feature
- [X] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
k-area-blocker have no indication whether it is visible or not. 


**What is the new behavior?**
k-area-blocker root element will now have the visible class. 


**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kaltura/kaltura-ng/41)
<!-- Reviewable:end -->
