### PR TITLE
escape ampersand character in xml content to prevent parsing error in FF

### DIFF
--- a/kaltura-common/src/xml-parser/xml-parser.ts
+++ b/kaltura-common/src/xml-parser/xml-parser.ts
@@ -63,7 +63,8 @@ export class XmlParser
 {
     static toJson(xml : string) : {}
     {
-        return XmlToJSON.parseString(xml,
+        const escapedString = String(xml).replace(/&/g, '&amp;'); // fix for Firefox
+        return XmlToJSON.parseString(escapedString,
             {
                 textKey: 'text', 	// tag name for text nodes
                 valueKey: 'value', 	// tag name for attribute values


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The app cannot start in Firefox if custom metadata has ampersand in its value


**What is the new behavior?**
Escape & character before parsing


**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**
