### PR TITLE
fix(copy-to-clipboard): copying in IE11 gets error KMCNG-2319

### DIFF
--- a/projects/kaltura-ng/mc-shared/src/lib/copy-to-clipboard/copy-to-clipboard.component.ts
+++ b/projects/kaltura-ng/mc-shared/src/lib/copy-to-clipboard/copy-to-clipboard.component.ts
@@ -52,12 +52,10 @@ export class CopyToClipboardComponent implements OnInit {
 
   private _copyElement(el: HTMLInputElement): 'success' | 'failure' {
     try {
-      if (document.body['createTextRange']) {
+      if (window['clipboardData']) {
         // IE
-        const textRange = document.body['createTextRange']();
-        textRange.moveToElementText(el);
-        textRange.select();
-        textRange.execCommand('Copy');
+        window['clipboardData'].clearData();
+        window['clipboardData'].setData('Text', el.value);
         return 'success';
       } else if (window.getSelection && document.createRange) {
         // non-IE


### PR DESCRIPTION
### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Throws error "Unspecified error" on line `textRange.select();`

**What is the new behavior?**

Changed approach to using window.clipboardData

**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**

**How should this be manually tested?**

**Any background context you want to provide?**
