### PR TITLE
fix: add word-break to details-bar

### DIFF
--- a/projects/kaltura-ng/kaltura-ui/src/lib/details-bar/detail-info.component.scss
+++ b/projects/kaltura-ng/kaltura-ui/src/lib/details-bar/detail-info.component.scss
@@ -2,14 +2,16 @@
 
 .kDetailInfo {
     display: flex;
-    line-height: 26px;
-    height: 26px;
+    min-height: 26px;
     .kDetails{
         display: flex;
         overflow: hidden;
         >div, >span, >a{
             flex: 0 0 auto;
-            line-height: 26px;
+        }
+        span:not(.kLabel) {
+            max-width: 82%;
+            word-break: break-all;
         }
     }
 

--- a/projects/kaltura-ng/kaltura-ui/src/lib/details-bar/details-bar.component.scss
+++ b/projects/kaltura-ng/kaltura-ui/src/lib/details-bar/details-bar.component.scss
@@ -1,7 +1,6 @@
 .kDetailsBar {
   display: block;
-  height: 26px;
-  line-height: 26px;
+  min-height: 26px;
   overflow-y: hidden;
   font-size: 14px;
   color: #666666;


### PR DESCRIPTION
make long words, e.g. userid, break and be visible
instead of invisible due to overflow: hidden

### PR information
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [] Feature
- [] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [] Build related changes
- [] CI related changes
- [] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
In details-bar, long words disappear due to overflow: hidden.

**What is the new behavior?**
Long words will break to a new line and be visible.
![details-bar-wordwrap](https://user-images.githubusercontent.com/66301426/155679840-ff8aba2b-b321-4f39-8009-1f7675d8152b.png)

**Does this PR introduce a breaking change?** (check one with "x")
- [] Yes
- [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

---

### Other information

**Where should the reviewer start?**
The scope of the change is very limited.
An overview should be possible at first glance.

**How should this be manually tested?**
In KMC, compare two entries with different owners. 
One should have long userid and the other should have a short userid.

**Any background context you want to provide?**
Recently, I had to work with long userids in KMC.
When reviewing an entry the userid of the owner would overflow and not be visible.
It started to bother me.